### PR TITLE
Implement voice and file upload in chat

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -12,6 +12,8 @@ interface ChatInputProps {
   onVoiceRecording: () => void;
   onFileUpload: (event: React.ChangeEvent<HTMLInputElement>) => void;
   isLoading: boolean;
+  isRecording?: boolean;
+  isUploading?: boolean;
   placeholder?: string;
 }
 
@@ -22,6 +24,8 @@ const ChatInput: React.FC<ChatInputProps> = ({
   onVoiceRecording,
   onFileUpload,
   isLoading,
+  isRecording = false,
+  isUploading = false,
   placeholder = "Ask anything..."
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -60,25 +64,25 @@ const ChatInput: React.FC<ChatInputProps> = ({
       <div className="flex items-center justify-end gap-1 mt-2">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              onClick={onVoiceRecording} 
-              disabled={isLoading}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onVoiceRecording}
+              disabled={isLoading || isUploading}
             >
-              <Mic className="w-4 h-4 text-gray-400 hover:text-white" />
+              <Mic className={`w-4 h-4 ${isRecording ? 'text-red-500 animate-pulse' : 'text-gray-400 hover:text-white'}`} />
             </Button>
           </TooltipTrigger>
-          <TooltipContent><p>Record Voice (coming soon)</p></TooltipContent>
+          <TooltipContent><p>{isRecording ? 'Stop Recording' : 'Record Voice'}</p></TooltipContent>
         </Tooltip>
         
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button 
-              variant="ghost" 
-              size="icon" 
-              onClick={triggerFileUpload} 
-              disabled={isLoading}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={triggerFileUpload}
+              disabled={isLoading || isUploading || isRecording}
             >
               <Paperclip className="w-4 h-4 text-gray-400 hover:text-white" />
             </Button>
@@ -86,13 +90,19 @@ const ChatInput: React.FC<ChatInputProps> = ({
           <TooltipContent><p>Attach File</p></TooltipContent>
         </Tooltip>
         
-        <input 
-          type="file" 
-          ref={fileInputRef} 
-          onChange={onFileUpload} 
-          className="hidden" 
-          accept="image/*, .pdf, .doc, .docx" 
+        <input
+          type="file"
+          ref={fileInputRef}
+          onChange={onFileUpload}
+          className="hidden"
+          accept="image/*, .pdf, .doc, .docx"
         />
+        {isRecording && (
+          <span className="text-xs text-red-500 ml-2">Recording...</span>
+        )}
+        {isUploading && !isRecording && (
+          <span className="text-xs text-gray-300 ml-2 flex items-center"><svg className="w-3 h-3 mr-1 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="12" r="10" className="opacity-25"/><path d="M4 12a8 8 0 018-8" className="opacity-75"/></svg>Uploading...</span>
+        )}
       </div>
     </div>
   );

--- a/src/components/chat/ChatPane.tsx
+++ b/src/components/chat/ChatPane.tsx
@@ -20,6 +20,8 @@ const ChatPane = () => {
         handleSubmit,
         handleVoiceRecording,
         handleFileUpload,
+        isRecording,
+        isUploading,
         authRequired,
         clearAuthRequired,
         session
@@ -50,6 +52,8 @@ const ChatPane = () => {
     const handleChange = inGuestMode ? guestChat.handleInputChange : handleInputChange;
     const handleSubmitForm = inGuestMode ? guestChat.handleSubmit : handleSubmit;
     const sending = inGuestMode ? guestChat.isLoading : isLoading;
+    const recording = inGuestMode ? false : isRecording;
+    const uploading = inGuestMode ? false : isUploading;
 
     return (
         <div className="w-full h-full bg-card/80 backdrop-blur-xl border border-white/10 rounded-2xl shadow-2xl flex flex-col overflow-hidden">
@@ -72,6 +76,8 @@ const ChatPane = () => {
                 onVoiceRecording={handleVoiceRecording}
                 onFileUpload={handleFileUpload}
                 isLoading={sending}
+                isRecording={recording}
+                isUploading={uploading}
             />
 
             <Toaster />

--- a/src/hooks/chat/useChatInput.ts
+++ b/src/hooks/chat/useChatInput.ts
@@ -1,8 +1,14 @@
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { supabase } from '@/integrations/supabase/client';
 
-export const useChatInput = () => {
+export type SubmitFn = (content: string) => Promise<boolean>;
+export const useChatInput = (submitMessage: SubmitFn) => {
   const [input, setInput] = useState('');
+  const [isRecording, setIsRecording] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInput(e.target.value);
@@ -10,16 +16,69 @@ export const useChatInput = () => {
 
   const clearInput = () => setInput('');
 
-  const handleVoiceRecording = () => {
-    console.log("Voice recording initiated.");
-    alert("Voice recording is not yet implemented.");
+  const handleVoiceRecording = async () => {
+    try {
+      if (isRecording) {
+        mediaRecorderRef.current?.stop();
+        return;
+      }
+
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const recorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e: BlobEvent) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+
+      recorder.onstop = async () => {
+        setIsRecording(false);
+        stream.getTracks().forEach(t => t.stop());
+        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
+        setIsUploading(true);
+        const filePath = `voice-${Date.now()}.webm`;
+        const { error } = await supabase.storage
+          .from('chat-uploads')
+          .upload(filePath, blob, { contentType: 'audio/webm' });
+        if (!error) {
+          const { data } = supabase.storage
+            .from('chat-uploads')
+            .getPublicUrl(filePath);
+          await submitMessage(data.publicUrl);
+        } else {
+          console.error('Audio upload error', error);
+        }
+        setIsUploading(false);
+      };
+
+      recorder.start();
+      setIsRecording(true);
+    } catch (err) {
+      console.error('Voice recording error', err);
+    }
   };
 
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files && event.target.files[0]) {
-      const file = event.target.files[0];
-      console.log("File selected:", file.name);
-      alert(`File "${file.name}" attached (upload functionality not implemented).`);
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      setIsUploading(true);
+      const filePath = `upload-${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage
+        .from('chat-uploads')
+        .upload(filePath, file, { contentType: file.type });
+      if (!error) {
+        const { data } = supabase.storage
+          .from('chat-uploads')
+          .getPublicUrl(filePath);
+        await submitMessage(data.publicUrl);
+      } else {
+        console.error('File upload error', error);
+      }
+    } finally {
+      setIsUploading(false);
+      event.target.value = '';
     }
   };
 
@@ -29,5 +88,7 @@ export const useChatInput = () => {
     clearInput,
     handleVoiceRecording,
     handleFileUpload,
+    isRecording,
+    isUploading,
   };
 };

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -14,8 +14,7 @@ export const useChat = (agentIdOverride?: AgentId) => {
   const { session, userId, userProfile, authRequired, setAuthRequired, clearAuthRequired } = useAuthState();
   const { threadId, isLoadingThread } = useThread(userId, selectedAgent);
   const { messages, isLoadingMessages, addMessageMutation, logUsage } = useMessages(threadId, selectedAgent, userProfile);
-  const { input, handleInputChange, clearInput, handleVoiceRecording, handleFileUpload } = useChatInput();
-  
+
   const { submitMessage, isSubmitting } = useMessageSubmission({
     threadId,
     selectedAgent,
@@ -25,6 +24,8 @@ export const useChat = (agentIdOverride?: AgentId) => {
     logUsage,
     setAuthRequired,
   });
+
+  const { input, handleInputChange, clearInput, handleVoiceRecording, handleFileUpload, isRecording, isUploading } = useChatInput(submitMessage);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -43,6 +44,8 @@ export const useChat = (agentIdOverride?: AgentId) => {
     handleSubmit,
     handleVoiceRecording,
     handleFileUpload,
+    isRecording,
+    isUploading,
     authRequired,
     clearAuthRequired,
     session,


### PR DESCRIPTION
## Summary
- add MediaRecorder-based voice recording
- upload files to Supabase storage
- show recording/uploading states in chat input

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685134170a54832eaf1388265cfa4ae1