### PR TITLE
Fix OpenRouter key requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 **URL**: https://lovable.dev/projects/153afdbe-684e-419e-a6e3-9aad59f987cf
 
+## Environment Setup
+
+The application requires an **OpenRouter API key** to enable AI features. Provide this key in a `.env` file using either of the following variables:
+
+```bash
+VITE_OPENROUTER_API_KEY=<your_api_key>
+# or
+OPENROUTER_API_KEY=<your_api_key>
+```
+
+The app will throw an error on startup if neither variable is defined. See `.env.example` for all available options.
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -4,10 +4,18 @@ import { Message } from '@/types/chat';
 import { AgentId } from '@/context/ChatContext';
 import { systemPrompts, modelMap } from '@/config/agentConfig';
 
-const openRouterApiKey = import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
+const openRouterApiKey =
+  import.meta.env.VITE_OPENROUTER_API_KEY ||
+  import.meta.env.OPENROUTER_API_KEY;
+
+if (!openRouterApiKey) {
+  throw new Error(
+    "OpenRouter API key not found. Please define VITE_OPENROUTER_API_KEY or OPENROUTER_API_KEY in your environment."
+  );
+}
 
 const openrouter = new OpenAI({
-  apiKey: openRouterApiKey || "dummy-key",
+  apiKey: openRouterApiKey,
   baseURL: "https://openrouter.ai/api/v1",
   dangerouslyAllowBrowser: true,
 });


### PR DESCRIPTION
## Summary
- require OpenRouter API key to be set in `aiService`
- document API key requirement in README

## Testing
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_685132e1c298832e8ace87d4abac28c6