### PR TITLE
Enhance dark theme backgrounds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,8 +79,8 @@ const App = () => {
             <Sonner />
             {/* Modern AI-styled background */}
             <div className="relative min-h-screen w-full bg-gradient-to-br from-black via-gray-950 to-black font-spacegrotesk overflow-x-hidden z-0">
-              <div className="absolute inset-0 bg-grid-pattern opacity-[0.02]" />
-              <div className="absolute inset-0 bg-gradient-to-t from-green/5 via-transparent to-transparent" />
+              <div className="absolute inset-0 bg-grid-pattern opacity-[0.02] -z-20" />
+              <div className="absolute inset-0 bg-gradient-to-t from-green/5 via-transparent to-transparent -z-10" />
               <ParticleBackground />
               <NeuralNetworkOverlay />
               {/* Content sits above the backgrounds */}

--- a/src/components/NeuralNetworkOverlay.tsx
+++ b/src/components/NeuralNetworkOverlay.tsx
@@ -5,7 +5,7 @@ const NeuralNetworkOverlay = () => (
     viewBox="0 0 800 800"
     width="100%"
     height="100%"
-    className="absolute inset-0 pointer-events-none z-0"
+    className="absolute inset-0 pointer-events-none -z-10"
     style={{
       opacity: 0.3,
       filter: "blur(0.5px)",

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -6,7 +6,7 @@ const NeuralNetworkOverlay = () => (
     viewBox="0 0 800 800"
     width="100%"
     height="100%"
-    className="absolute inset-0 pointer-events-none z-0"
+    className="absolute inset-0 pointer-events-none -z-10"
     style={{
       opacity: 0.5,
       filter: "blur(0.5px)",

--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,8 @@
 
   body {
     @apply text-white font-inter;
-    background: #121212;
+    /* Futuristic dark gradient */
+    background: radial-gradient(at top left, #1a1a1a, #0a0a0a);
     background-attachment: fixed;
     min-height: 100vh;
     line-height: 1.6;


### PR DESCRIPTION
## Summary
- adjust body background to a dark radial gradient
- ensure background overlays sit behind content
- move neural network overlays behind the page

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853e1c39174832e9170d9573faf0de7