### PR TITLE
Refactor to Vite, add withdraw page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables
+VITE_OPENROUTER_API_KEY=your-openrouter-key
+VITE_TWELVEDATA_API_KEY=your-twelvedata-key
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # Production
 /build
+dist/
 
 # Misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
-    "lint": "next lint",
-    "start": "next start"
+    "build": "vite build",
+    "dev": "vite dev",
+    "lint": "eslint .",
+    "start": "vite preview"
   },
   "dependencies": {
     "@emotion/is-prop-valid": "latest",
     "@eslint/js": "latest",
+    "@fontsource/space-grotesk": "^5.2.8",
     "@radix-ui/react-accordion": "latest",
     "@radix-ui/react-alert-dialog": "latest",
     "@radix-ui/react-aspect-ratio": "latest",
@@ -88,8 +89,6 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-rtl": "latest",
-    "tempo-devtools": "latest",
-    "tempo-routes": "latest",
     "terser": "latest",
     "tsx": "latest",
     "typescript-eslint": "latest",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import CryptoPage from "./pages/CryptoPage"
 import ArbitragePage from "./pages/ArbitragePage"
 import AcademyPage from "./pages/AcademyPage"
 import DepositPage from "./pages/DepositPage"
+import WithdrawPage from "./pages/WithdrawPage"
 import NotFound from "./pages/NotFound"
 import WelcomePage from "./pages/WelcomePage"
 import HowItWorksPage from "./pages/HowItWorksPage"
@@ -23,7 +24,6 @@ import { useEffect } from "react"
 import { WalletProvider } from "./context/WalletProvider"
 import ParticleBackground from "@/components/ParticleBackground"
 import NeuralNetworkOverlay from "@/components/NeuralNetworkOverlay"
-import routes from "tempo-routes"
 import { useRoutes } from "react-router-dom"
 
 import "@solana/wallet-adapter-react-ui/styles.css"
@@ -32,7 +32,6 @@ const queryClient = new QueryClient()
 
 const AppRoutes = () => {
   // Tempo routes - must be called inside Router context
-  const tempoRoutes = import.meta.env.VITE_TEMPO ? useRoutes(routes) : null
 
   return (
     <Routes>
@@ -46,9 +45,8 @@ const AppRoutes = () => {
       <Route path="/agents/arbitrage" element={<ArbitragePage />} />
       <Route path="/academy" element={<AcademyPage />} />
       <Route path="/deposit" element={<DepositPage />} />
+      <Route path="/withdraw" element={<WithdrawPage />} />
       <Route path="/how-it-works" element={<HowItWorksPage />} />
-      {/* Add this before the catchall route */}
-      {import.meta.env.VITE_TEMPO && <Route path="/tempobook/*" />}
       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
       <Route path="*" element={<NotFound />} />
     </Routes>
@@ -57,7 +55,6 @@ const AppRoutes = () => {
 
 const App = () => {
   const { i18n } = useTranslation()
-  const tempoRoutes = import.meta.env.VITE_TEMPO ? useRoutes(routes) : null
 
   useEffect(() => {
     document.documentElement.dir = i18n.language === "ar" ? "rtl" : "ltr"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,3 @@
-import { TempoDevtools } from "tempo-devtools";
-TempoDevtools.init();
 
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";

--- a/src/pages/DepositPage.tsx
+++ b/src/pages/DepositPage.tsx
@@ -18,9 +18,13 @@ import {
   Coins,
 } from "lucide-react";
 
-const DepositPage: React.FC = () => {
+interface DepositPageProps {
+  initialTab?: "deposit" | "withdraw";
+}
+
+const DepositPage: React.FC<DepositPageProps> = ({ initialTab = "deposit" }) => {
   const tab =
-    new URLSearchParams(window.location.search).get("tab") || "deposit";
+    new URLSearchParams(window.location.search).get("tab") || initialTab;
 
   const depositOptions = [
     {

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import DepositPage from "./DepositPage";
+
+const WithdrawPage: React.FC = () => {
+  return <DepositPage initialTab="withdraw" />;
+};
+
+export default WithdrawPage;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,17 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { tempo } from "tempo-devtools/dist/vite";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
-    // @ts-ignore
-    allowedHosts: process.env.TEMPO === "true" ? true : undefined,
   },
-  plugins: [react(), tempo()].filter(Boolean),
+  plugins: [react()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- remove unused Tempo tools and switch scripts to Vite
- strip Tempo references from main entry and config
- add example environment file
- allow `DepositPage` to select initial tab and create new `WithdrawPage`
- route `/withdraw` to new page

## Testing
- `npm run build`
- `npm run lint` *(fails: 51 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6853f47260e0832eaa6719119845bff5