### PR TITLE
Fix layout overlap and unify backgrounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <title>Ruyaa-AI</title>
     <meta name="description" content="Ruyaa-AI — AI-powered trading &amp; assistant engine" />
 
+    <link rel="icon" href="/favicon.ico" />
+
     <meta property="og:title" content="Ruyaa-AI" />
     <meta property="og:description" content="AI-powered trading &amp; assistant engine" />
     <meta property="og:type" content="website" />

--- a/src/components/AgentDetailModal.tsx
+++ b/src/components/AgentDetailModal.tsx
@@ -39,7 +39,7 @@ const AgentDetailModal: React.FC<AgentDetailModalProps> = ({ type, onClose }) =>
 
     const handleStart = () => {
         if (type === 'mt') {
-            navigate('/agents/mt4');
+            navigate('/agents/mt4mt5');
         } else if (type === 'crypto') {
             navigate('/agents/crypto');
         }

--- a/src/components/OptionCard.tsx
+++ b/src/components/OptionCard.tsx
@@ -27,7 +27,7 @@ const OptionCard: React.FC<OptionCardProps> = ({
     className="relative group"
   >
     <Card
-      className={`bg-gradient-to-br from-gray-800/40 to-gray-900/60 border border-gray-700 hover:border-gray-500 transition-all duration-300 h-full ${comingSoon ? "opacity-75" : ""}`}
+      className={`bg-[#1a1a1a] border border-[#3f352e] hover:border-[#57493e] transition-all duration-300 h-full ${comingSoon ? "opacity-75" : ""}`}
     >
       <CardHeader className="pb-4">
         <div className="flex items-center gap-3 mb-2">
@@ -47,14 +47,14 @@ const OptionCard: React.FC<OptionCardProps> = ({
         {href ? (
           <a
             href={href}
-            className={`inline-flex items-center justify-center w-full py-2 rounded-md bg-gray-700/50 hover:bg-gray-700 text-white border border-gray-600 hover:border-gray-400 transition-all duration-300 ${comingSoon ? "cursor-not-allowed opacity-50" : ""}`}
+            className={`inline-flex items-center justify-center w-full py-2 rounded-md bg-[#1f1b18] hover:bg-[#2a2623] text-white border border-[#3f352e] hover:border-[#57493e] transition-all duration-300 ${comingSoon ? "cursor-not-allowed opacity-50" : ""}`}
           >
             {comingSoon ? "Coming Soon" : "Select"}
             {!comingSoon && <ArrowRight className="w-4 h-4 ml-2" />}
           </a>
         ) : (
           <Button
-            className={`w-full bg-gray-700/50 hover:bg-gray-700 text-white border border-gray-600 hover:border-gray-400 transition-all duration-300 ${comingSoon ? "cursor-not-allowed opacity-50" : ""}`}
+            className={`w-full bg-[#1f1b18] hover:bg-[#2a2623] text-white border border-[#3f352e] hover:border-[#57493e] transition-all duration-300 ${comingSoon ? "cursor-not-allowed opacity-50" : ""}`}
             disabled={comingSoon}
           >
             {comingSoon ? "Coming Soon" : "Select"}
@@ -64,7 +64,7 @@ const OptionCard: React.FC<OptionCardProps> = ({
       </CardContent>
     </Card>
     <div
-      className="absolute inset-0 bg-gray-800 rounded-lg blur-xl opacity-0 group-hover:opacity-20 transition-opacity duration-300 -z-10"
+      className="absolute inset-0 bg-black rounded-lg blur-xl opacity-0 group-hover:opacity-30 transition-opacity duration-300 -z-10"
     />
   </motion.div>
 );

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -50,13 +50,13 @@ const ParticleBackground = () => {
       },
       particles: {
         color: {
-          value: ["#FFD700", "#FFA500", "#ffffff"],
+          value: ["#ffffff", "#aaaaaa"],
         },
         links: {
-          color: "#FFD700",
+          color: "#ffffff",
           distance: 120,
           enable: true,
-          opacity: 0.03,
+          opacity: 0.05,
           width: 0.5,
         },
         move: {

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ParticleBackground from "@/components/ParticleBackground";
+import FuturisticBackground from "@/components/FuturisticBackground";
 
 const NeuralNetworkOverlay = () => (
   <svg
@@ -28,8 +29,11 @@ const NeuralNetworkOverlay = () => (
 );
 
 const DashboardLayout = ({ children }: { children: React.ReactNode }) => (
-  <div className="relative min-h-screen w-full font-spacegrotesk overflow-x-hidden z-0">
-    <div className="relative z-10 w-full max-w-7xl mx-auto px-4 py-16">
+  <div className="relative min-h-screen w-full font-spacegrotesk overflow-x-hidden z-0 flex items-start justify-center pt-40 pb-24">
+    <FuturisticBackground />
+    <ParticleBackground />
+    <NeuralNetworkOverlay />
+    <div className="relative z-10 w-full max-w-7xl mx-auto px-4">
       {children}
     </div>
   </div>

--- a/src/components/dashboard/FeatureCTA.tsx
+++ b/src/components/dashboard/FeatureCTA.tsx
@@ -12,22 +12,20 @@ const FeatureCTA: React.FC<FeatureCTAProps> = ({ onActivate }) => {
     <motion.div
       initial={{ opacity: 0, y: 24 }}
       animate={{ opacity: 1, y: 0 }}
-      whileHover={{ y: -8, boxShadow: "0 0 32px #00FF9D88" }}
       transition={{ type: "spring", stiffness: 60 }}
-      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden flex flex-col items-center text-center shadow-md focus-within:ring-2 focus-within:ring-green-400 outline-none group"
+      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden flex flex-col items-center text-center shadow-md focus-within:ring-2 focus-within:ring-green-400 outline-none"
       tabIndex={0}
       aria-label="Activate features"
     >
-      <div className="absolute inset-0 bg-green-500/10 blur-2xl -z-10" aria-hidden />
+      <div className="absolute inset-0 bg-black/40 blur-xl -z-10" aria-hidden />
       <span className="flex mb-3">
-        <Bolt className="w-7 h-7 text-green-400 animate-pulse-glow drop-shadow-[0_0_8px_#00FF9D]" strokeWidth={2.2} />
+        <Bolt className="w-7 h-7 text-green-400" strokeWidth={2.2} />
       </span>
       <h3 className="text-xl font-bold text-white mb-3 tracking-tight">Unlock &amp; Start Profiting</h3>
       <Button
         onClick={onActivate}
-        className="px-8 py-3 rounded-full border-2 border-green-400 shadow-green-glow text-green-200 bg-green-500/10 hover:bg-green-400 hover:text-black focus-visible:ring-2 focus-visible:ring-green-400 font-semibold text-base transition-all animate-pulse"
+        className="px-8 py-3 rounded-full border-2 border-green-400 text-green-200 bg-green-800/20 hover:bg-green-600/30 focus-visible:ring-2 focus-visible:ring-green-400 font-semibold text-base transition-all"
         tabIndex={0}
-        style={{ boxShadow: "0 0 16px #00FF9D55" }}
       >
         Activate Features
       </Button>

--- a/src/components/dashboard/ProfileCard.tsx
+++ b/src/components/dashboard/ProfileCard.tsx
@@ -29,19 +29,18 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile, email }) => {
     <motion.div
       initial={{ opacity: 0, y: 18 }}
       animate={{ opacity: 1, y: 0 }}
-      whileHover={{ y: -8, boxShadow: "0 0 28px #00FF9D99" }}
       transition={{ type: "spring", stiffness: 50, damping: 16 }}
-      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none group"
+      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none"
       tabIndex={0}
       aria-label="Profile information"
     >
-      <div className="absolute inset-0 bg-green-500/10 blur-2xl -z-10 transition-all duration-300 group-hover:blur-xl" aria-hidden />
-      <div className="absolute top-4 left-4 text-green-400 drop-shadow-[0_0_10px_#00FF9D]">
+      <div className="absolute inset-0 bg-black/40 blur-xl -z-10" aria-hidden />
+      <div className="absolute top-4 left-4 text-green-400">
         <User strokeWidth={2.2} className="w-6 h-6" />
       </div>
       <div className="flex items-center gap-5 mt-2 mb-6">
         <div className="flex-shrink-0">
-          <Avatar className="h-16 w-16 ring-2 ring-green-400 shadow-green-glow transition-shadow animate-pulse-slow">
+          <Avatar className="h-16 w-16 ring-2 ring-green-400">
             <AvatarImage src={profile?.avatar_url ?? undefined} alt={profile?.full_name ?? "User"} />
             <AvatarFallback className="bg-gray-800 text-white font-bold">{getInitials(profile?.full_name)}</AvatarFallback>
           </Avatar>
@@ -54,7 +53,7 @@ const ProfileCard: React.FC<ProfileCardProps> = ({ profile, email }) => {
       <Button
         variant="ghost"
         onClick={() => setModalOpen(true)}
-        className="px-6 py-2 rounded-full border border-green-400 text-green-300 hover:bg-green-500/10 hover:text-white focus-visible:ring-2 focus-visible:ring-green-400 transition-all font-semibold text-base shadow-green-glow"
+        className="px-6 py-2 rounded-full border border-green-400 text-green-300 hover:bg-green-600/20 hover:text-white focus-visible:ring-2 focus-visible:ring-green-400 transition-all font-semibold text-base"
         tabIndex={0}
       >
         Edit Profile

--- a/src/components/dashboard/SessionsCard.tsx
+++ b/src/components/dashboard/SessionsCard.tsx
@@ -30,15 +30,15 @@ const SessionsCard: React.FC<SessionsCardProps> = ({ sessions, onStartNow }) => 
     <motion.div
       initial={{ opacity: 0, y: 18 }}
       animate={{ opacity: 1, y: 0 }}
-      whileHover={{ y: -8, boxShadow: "0 0 28px #00FF9D88" }}
+      whileHover={{ y: -6, boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
       transition={{ type: "spring", stiffness: 50 }}
       className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none group"
       tabIndex={0}
       aria-label="Arbitrage sessions"
     >
-      <div className="absolute inset-0 bg-green-500/10 blur-2xl -z-10" aria-hidden />
+      <div className="absolute inset-0 bg-black/40 blur-xl -z-10" aria-hidden />
       <div className="flex items-center mb-4 gap-2">
-        <ArrowUp className="w-6 h-6 text-green-400 drop-shadow-[0_0_8px_#00FF9D]" strokeWidth={2.2} />
+        <ArrowUp className="w-6 h-6 text-green-400" strokeWidth={2.2} />
         <h3 className="text-xl font-bold text-white tracking-tight">Arbitrage Sessions</h3>
       </div>
       {sessions && sessions.length > 0 ? (
@@ -68,7 +68,7 @@ const SessionsCard: React.FC<SessionsCardProps> = ({ sessions, onStartNow }) => 
           <p className="text-green-100 text-base">No active arbitrage.</p>
           <Button
             onClick={onStartNow}
-            className="rounded-full px-7 py-3 border-2 border-green-400 bg-green-600/20 text-green-200 shadow-green-glow hover:bg-green-400 hover:text-black focus-visible:ring-green-400 focus-visible:outline-none font-semibold text-base transition-all group animate-pulse-glow"
+            className="rounded-full px-7 py-3 border-2 border-green-400 bg-green-800/20 text-green-200 hover:bg-green-600/30 focus-visible:ring-green-400 focus-visible:outline-none font-semibold text-base transition-all"
             tabIndex={0}
           >
             Start Now<span className="ml-2"><ArrowUp className="w-4 h-4" /></span>

--- a/src/components/dashboard/WalletsCard.tsx
+++ b/src/components/dashboard/WalletsCard.tsx
@@ -133,23 +133,23 @@ const WalletsCard: React.FC<WalletsCardProps> = ({ wallets, onAddWallet }) => {
     <motion.div
       initial={{ opacity: 0, y: 18 }}
       animate={{ opacity: 1, y: 0 }}
-      whileHover={{ y: -8, boxShadow: "0 0 28px #00FF9D99" }}
+      whileHover={{ y: -6, boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
       transition={{ type: "spring", stiffness: 50 }}
       className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none group"
       tabIndex={0}
       aria-label="Wallet manager"
     >
-      <div className="absolute inset-0 bg-green-500/10 blur-2xl -z-10" aria-hidden />
+      <div className="absolute inset-0 bg-black/40 blur-xl -z-10" aria-hidden />
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <span className="rounded-full bg-green-500/10 w-7 h-7 flex items-center justify-center shadow-green-glow">
-            <Plus className="w-5 h-5 text-green-400 drop-shadow-[0_0_7px_#00FF9D]" strokeWidth={2.3} />
+          <span className="rounded-full bg-green-800/20 w-7 h-7 flex items-center justify-center">
+            <Plus className="w-5 h-5 text-green-400" strokeWidth={2.3} />
           </span>
           <h3 className="text-xl font-bold text-white tracking-tight">My Wallets</h3>
         </div>
         <Button
           onClick={handleConnectWallet}
-          className="rounded-full border-2 border-green-400 bg-green-600/20 text-green-200 shadow-green-glow px-5 py-2 hover:bg-green-400 hover:text-black transition-all focus-visible:ring-2 focus-visible:ring-green-400 font-semibold text-base inline-flex items-center gap-2"
+          className="rounded-full border-2 border-green-400 bg-green-800/20 text-green-200 hover:bg-green-600/30 transition-all focus-visible:ring-2 focus-visible:ring-green-400 font-semibold text-base inline-flex items-center gap-2"
           tabIndex={0}
           aria-label="Add wallet"
         >

--- a/src/pages/AcademyPage.tsx
+++ b/src/pages/AcademyPage.tsx
@@ -10,6 +10,8 @@ import CourseCurriculum from "@/components/CourseCurriculum";
 import CourseProgress from "@/components/CourseProgress";
 import QuizModal from "@/components/academy/QuizModal";
 import AIStatsCard from "@/components/academy/AIStatsCard";
+import ParticleBackground from "@/components/ParticleBackground";
+import FuturisticBackground from "@/components/FuturisticBackground";
 import {
   useCourseData,
   useLessonsData,
@@ -136,7 +138,9 @@ const AcademyPage = () => {
 
   if (coursesLoading || lessonsLoading) {
     return (
-      <div className="min-h-screen bg-[#0D0D0D]" dir={isArabic ? "rtl" : "ltr"}>
+      <div className="relative min-h-screen bg-[#0D0D0D]" dir={isArabic ? "rtl" : "ltr"}>
+        <FuturisticBackground />
+        <ParticleBackground />
         <Navbar />
         <div className="pt-32 flex items-center justify-center min-h-[60vh]">
           <div className="text-center">
@@ -157,7 +161,9 @@ const AcademyPage = () => {
   }
 
   return (
-    <div className="min-h-screen bg-[#0D0D0D]" dir={isArabic ? "rtl" : "ltr"}>
+    <div className="relative min-h-screen bg-[#0D0D0D]" dir={isArabic ? "rtl" : "ltr"}>
+      <FuturisticBackground />
+      <ParticleBackground />
       <Navbar />
 
       <main className="pt-32 pb-20">

--- a/src/pages/ArbitragePage.tsx
+++ b/src/pages/ArbitragePage.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import Navbar from '@/components/Navbar';
 import AgentChat from '@/components/AgentChat';
 import ParticleBackground from '@/components/ParticleBackground';
+import FuturisticBackground from '@/components/FuturisticBackground';
 import { useTranslation } from 'react-i18next';
 
 const ArbitragePage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
       <main className="pt-32 pb-20 w-full">

--- a/src/pages/CryptoPage.tsx
+++ b/src/pages/CryptoPage.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import Navbar from '@/components/Navbar';
 import AgentChat from '@/components/AgentChat';
 import ParticleBackground from '@/components/ParticleBackground';
+import FuturisticBackground from '@/components/FuturisticBackground';
 import { useTranslation } from 'react-i18next';
 
 const CryptoPage: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
       <main className="pt-32 pb-20 w-full">

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -4,6 +4,8 @@ import { supabase } from "@/integrations/supabase/client";
 import { useNavigate } from "react-router-dom";
 import Navbar from "@/components/Navbar";
 import DashboardLayout from "@/components/dashboard/DashboardLayout";
+import FuturisticBackground from "@/components/FuturisticBackground";
+import ParticleBackground from "@/components/ParticleBackground";
 import ProfileCard from "@/components/dashboard/ProfileCard";
 import FeatureCTA from "@/components/dashboard/FeatureCTA";
 import SessionsCard from "@/components/dashboard/SessionsCard";
@@ -100,7 +102,9 @@ const DashboardPage = () => {
   const featuresActive = dashboardData?.features && dashboardData.features.length > 0;
 
   return (
-    <div className="relative min-h-screen bg-[#0D0D0D] font-spacegrotesk">
+    <div className="relative min-h-screen bg-[#0D0D0D] font-spacegrotesk overflow-hidden">
+      <FuturisticBackground />
+      <ParticleBackground />
       <Navbar />
       <DashboardLayout>
         <motion.div

--- a/src/pages/HowItWorksPage.tsx
+++ b/src/pages/HowItWorksPage.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { motion } from "framer-motion";
 import Navbar from "@/components/Navbar";
 import ParticleBackground from "@/components/ParticleBackground";
+import FuturisticBackground from "@/components/FuturisticBackground";
 import { Brain, Zap, Bot, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
@@ -11,6 +12,7 @@ const HowItWorksPage: React.FC = () => {
 
   return (
     <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -200,7 +200,7 @@ const Index = () => {
             >
               <motion.button
                 onClick={handleStartNowClick}
-                className="bg-gradient-to-r from-yellow-600 to-yellow-500 text-black px-8 py-4 rounded-xl font-bold shadow-lg hover:shadow-xl hover:scale-102 transition-all duration-300 inline-flex items-center gap-2"
+                className="px-8 py-4 rounded-xl font-bold bg-[#1f1b18] text-white border border-[#3f352e] hover:bg-[#2a2623] hover:border-[#57493e] transition-all duration-300 inline-flex items-center gap-2"
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >

--- a/src/pages/MT4Page.tsx
+++ b/src/pages/MT4Page.tsx
@@ -2,13 +2,15 @@
 import React from 'react';
 import Navbar from '@/components/Navbar';
 import ParticleBackground from '@/components/ParticleBackground';
+import FuturisticBackground from '@/components/FuturisticBackground';
 import AgentChat from '@/components/AgentChat';
 import { useTranslation } from 'react-i18next';
 
 const MT4Page: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="relative min-h-screen">
+    <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
       <main className="pt-32 pb-20 w-full flex justify-center">

--- a/src/pages/MarketPage.tsx
+++ b/src/pages/MarketPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Navbar from "@/components/Navbar";
 import ParticleBackground from "@/components/ParticleBackground";
+import FuturisticBackground from "@/components/FuturisticBackground";
 import AIMarketTable from "@/components/AIMarketTable";
 import ArbitrageTicker from "@/components/ArbitrageTicker";
 import { motion } from "framer-motion";
@@ -8,6 +9,7 @@ import { motion } from "framer-motion";
 const MarketPage: React.FC = () => {
   return (
     <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
       <main className="pt-32 pb-20 w-full max-w-5xl mx-auto px-6 space-y-12">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import FuturisticBackground from "@/components/FuturisticBackground";
+import ParticleBackground from "@/components/ParticleBackground";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,7 +14,9 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+    <div className="relative min-h-screen bg-[#0D0D0D] flex items-center justify-center">
+      <FuturisticBackground />
+      <ParticleBackground />
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Navbar from "@/components/Navbar";
 import ParticleBackground from "@/components/ParticleBackground";
+import FuturisticBackground from "@/components/FuturisticBackground";
 import ProfileSection from "@/components/dashboard/ProfileSection";
 import { useAuthState } from "@/hooks/chat/useAuthState";
 import type { Tables } from "@/integrations/supabase/types";
@@ -19,6 +20,7 @@ const ProfilePage: React.FC = () => {
 
   return (
     <div className="relative min-h-screen bg-[#0D0D0D]">
+      <FuturisticBackground />
       <ParticleBackground />
       <Navbar />
       <main className="pt-32 pb-20 w-full max-w-4xl mx-auto px-6">


### PR DESCRIPTION
## Summary
- ensure every page uses the futuristic and particle backgrounds
- lighten particle colors and center dashboard cards
- tweak dashboard padding so cards don't overlap the navbar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68547be75768832e971951f3235672c0