### PR TITLE
Add broker registration form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import MarketPage from "./pages/MarketPage";
 import NotFound from "./pages/NotFound";
 import WelcomePage from "./pages/WelcomePage";
 import HowItWorksPage from "./pages/HowItWorksPage";
+import BrokerRegistrationPage from "./pages/BrokerRegistrationPage";
 import { ChatProvider } from "./context/ChatContext";
 import AuthPage from "./pages/AuthPage";
 import DashboardPage from "./pages/DashboardPage";
@@ -54,6 +55,7 @@ const AppRoutes = () => {
       <Route path="/profile" element={<ProfilePage />} />
       <Route path="/market" element={<MarketPage />} />
       <Route path="/how-it-works" element={<HowItWorksPage />} />
+      <Route path="/register/broker" element={<BrokerRegistrationPage />} />
       {/* Add this before the catchall route */}
       {import.meta.env.VITE_TEMPO && <Route path="/tempobook/*" />}
       {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/AgentChat.tsx
+++ b/src/components/AgentChat.tsx
@@ -72,14 +72,14 @@ const AgentChat: React.FC<AgentChatProps> = ({ agentId }) => {
                             className={cn(
                               'p-3 rounded-xl max-w-lg break-words whitespace-pre-wrap',
                               isUser
-                                ? 'bg-gold/90 text-dark-charcoal rounded-br-none'
+                                ? 'bg-card text-gold border border-gold/40 rounded-br-none'
                                 : 'bg-card text-white rounded-bl-none'
                             )}
                           >
                             <Linkify options={linkifyOptions(isUser)}>{message.content}</Linkify>
                           </div>
                           {isUser && (
-                            <div className="w-8 h-8 rounded-full bg-gold/20 flex items-center justify-center shrink-0">
+                            <div className="w-8 h-8 rounded-full bg-card border border-gold/40 flex items-center justify-center shrink-0">
                               <User className="w-5 h-5 text-gold" />
                             </div>
                           )}

--- a/src/components/FeatureGrid.tsx
+++ b/src/components/FeatureGrid.tsx
@@ -24,7 +24,7 @@ const FeatureGrid: React.FC = () => {
       }
       case "24/7 Ruyaa AI Assistant": {
         // Open chatbot
-        openChat(null);
+        openChat('support');
         break;
       }
       case "Trading Academy + Mentor": {

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -19,10 +19,10 @@ const ChatMessage = ({ message }: { message: Message }) => {
             )}
             <div
                 className={cn(
-                    'max-w-xs md:max-w-md p-3 rounded-xl text-white shadow-md',
+                    'max-w-xs md:max-w-md p-3 rounded-xl shadow-md',
                     isUser
-                        ? 'bg-primary-accent text-white rounded-br-none'
-                        : 'bg-white/10 rounded-bl-none'
+                        ? 'bg-card text-gold border border-gold/40 rounded-br-none'
+                        : 'bg-white/10 text-white rounded-bl-none'
                 )}
             >
                 <p className="text-sm leading-relaxed">{message.content}</p>

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -13,7 +13,7 @@ const ChatWidget = () => {
     if (isChatOpen) {
       closeChat();
     } else {
-      openChat(null); // Open generic chat if opened from widget button
+      openChat('support'); // Open generic chat if opened from widget button
     }
   };
 

--- a/src/components/dashboard/EditProfileModal.tsx
+++ b/src/components/dashboard/EditProfileModal.tsx
@@ -63,7 +63,13 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ open, onOpenChange,
           </div>
         </div>
         <DialogFooter>
-          <Button onClick={handleSaveProfile} disabled={saving} className="w-full">Save Profile</Button>
+          <Button
+            onClick={handleSaveProfile}
+            disabled={saving}
+            className="w-full bg-gray-800 border border-gray-600 text-white hover:bg-gray-700"
+          >
+            Save Profile
+          </Button>
         </DialogFooter>
         <div className="mt-4 pt-4 border-t border-gray-600">
           <label className="block mb-2 font-medium">Change Password</label>
@@ -75,7 +81,13 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({ open, onOpenChange,
             placeholder="New password"
             disabled={saving}
           />
-          <Button onClick={handleChangePassword} disabled={saving || !password} className="w-full mt-2">Change Password</Button>
+          <Button
+            onClick={handleChangePassword}
+            disabled={saving || !password}
+            className="w-full mt-2 bg-gray-800 border border-gray-600 text-white hover:bg-gray-700"
+          >
+            Change Password
+          </Button>
         </div>
         <DialogClose asChild>
           <Button variant="outline" className="absolute top-3 right-3" size="icon" aria-label="Close">×</Button>

--- a/src/components/forms/BrokerRegistrationForm.tsx
+++ b/src/components/forms/BrokerRegistrationForm.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/hooks/use-toast';
+
+const schema = z.object({
+  fullName: z.string().min(1, 'Required'),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  country: z.string().optional(),
+  platform: z.enum(['MT4', 'MT5']),
+  accountType: z.enum(['Standard', 'Pro']),
+  deposit: z.preprocess(v => Number(v), z.number().min(0).optional()),
+});
+
+type FormValues = z.infer<typeof schema> & { kyc?: FileList };
+
+const BrokerRegistrationForm: React.FC = () => {
+  const { toast } = useToast();
+  const [submitting, setSubmitting] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: FormValues) => {
+    setSubmitting(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const userId = session?.user.id ?? null;
+      let kycUrl: string | null = null;
+      if (values.kyc && values.kyc.length > 0) {
+        const file = values.kyc[0];
+        const filePath = `${userId ?? 'anon'}/${Date.now()}_${file.name}`;
+        const { error } = await supabase.storage.from('broker-docs').upload(filePath, file);
+        if (!error) {
+          const { data } = supabase.storage.from('broker-docs').getPublicUrl(filePath);
+          kycUrl = data.publicUrl;
+        }
+      }
+      await supabase.from('broker_registrations').insert({
+        user_id: userId,
+        full_name: values.fullName,
+        email: values.email,
+        phone: values.phone ?? null,
+        country: values.country ?? null,
+        platform: values.platform,
+        account_type: values.accountType,
+        deposit: values.deposit ?? null,
+        kyc_url: kycUrl,
+      });
+      toast({ title: 'Registration submitted', description: 'Our team will review your details shortly.' });
+      reset();
+    } catch (e) {
+      console.error(e);
+      toast({ title: 'Error', description: 'Submission failed', variant: 'destructive' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-lg mx-auto p-6 bg-[#1A1A1A] rounded-xl border border-gray-600">
+      <div>
+        <label className="block mb-1 text-sm font-medium">Full Name</label>
+        <Input {...register('fullName')} disabled={submitting} />
+        {errors.fullName && <p className="text-red-500 text-sm">{errors.fullName.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1 text-sm font-medium">Email</label>
+        <Input type="email" {...register('email')} disabled={submitting} />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1 text-sm font-medium">Phone</label>
+        <Input {...register('phone')} disabled={submitting} />
+      </div>
+      <div>
+        <label className="block mb-1 text-sm font-medium">Country</label>
+        <Input {...register('country')} disabled={submitting} />
+      </div>
+      <div className="flex gap-4">
+        <div className="flex-1">
+          <label className="block mb-1 text-sm font-medium">Platform</label>
+          <select {...register('platform')} className="w-full bg-[#131313] border border-gray-600 rounded-md p-2" disabled={submitting}>
+            <option value="MT4">MT4</option>
+            <option value="MT5">MT5</option>
+          </select>
+        </div>
+        <div className="flex-1">
+          <label className="block mb-1 text-sm font-medium">Account Type</label>
+          <select {...register('accountType')} className="w-full bg-[#131313] border border-gray-600 rounded-md p-2" disabled={submitting}>
+            <option value="Standard">Standard</option>
+            <option value="Pro">Pro</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label className="block mb-1 text-sm font-medium">Deposit (USD)</label>
+        <Input type="number" step="0.01" {...register('deposit')} disabled={submitting} />
+      </div>
+      <div>
+        <label className="block mb-1 text-sm font-medium">KYC Document (optional)</label>
+        <Input type="file" {...register('kyc')} disabled={submitting} />
+        <p className="text-xs text-gray-400 mt-1">Uploading helps verify your account faster.</p>
+      </div>
+      <Button type="submit" disabled={submitting} className="w-full bg-gray-800 border border-gray-600 text-white hover:bg-gray-700">
+        {submitting ? 'Submitting...' : 'Submit'}
+      </Button>
+    </form>
+  );
+};
+
+export default BrokerRegistrationForm;

--- a/src/config/agentConfig.ts
+++ b/src/config/agentConfig.ts
@@ -39,7 +39,7 @@ export const mt4SystemPrompt = `You are Ruyaa's MT4/MT5 Agent - a professional a
 • GREETING: Always greet users warmly. If you know their name, use it naturally in conversation.
 • EXPERTISE: Focus on Forex pairs, Gold trading, MT4/MT5 platform guidance.
 • LANGUAGE: Detect user language; after 4 switches ask which language to keep.
-• REGISTRATION FLOW: Guide one field at a time: name → country → email → platform (MT4/MT5) → account type (Standard/Pro) → deposit (min $100) → payment method.
+• REGISTRATION FLOW: Guide one field at a time: name → country → email → platform (MT4/MT5) → account type (Standard/Pro) → deposit (min $100) → payment method. If the user prefers a form, direct them to https://your-site.com/register/broker where they can optionally upload KYC docs for faster verification.
 • CASH PATH: For cash deposits, ask phone → country; if UAE/Syria ask city; if Aleppo show office address.
 • ACCOUNT TYPES: Standard vs Pro - emphasize AI extras for Pro (advanced signals, risk management).
 • COMPLETION: When complete, call register_user() and send confirmation.
@@ -97,7 +97,7 @@ Start with a clear example:
 4. **Ask mode** (Automatic AI or manual trades?)
 5. **Remind limits** (Daily arbitrage requires $5,000+)
 6. **Payment** ("Pay in crypto (USDT/SOL). Here's the wallet link:" \`<WALLET_LINK>\`)
-7. **Confirm & activate** ("Funds received—your arbitrage bot is now live! 🚀")
+7. **Confirm & activate** ("Funds received—your arbitrage bot is now live!")
 
 🔹 **RULES**
 • Never discuss topics outside arbitrage—redirect to Ruyaa Support.
@@ -140,6 +140,7 @@ export const systemPrompts: Record<string, string> = {
   mt4mt5: mt4SystemPrompt,
   crypto: cryptoSystemPrompt,
   arbitrage: arbitrageSystemPrompt,
+  support: generalSystemPrompt,
   general: generalSystemPrompt,
 };
 
@@ -147,5 +148,6 @@ export const modelMap: Record<string, string> = {
   mt4mt5: "openai/gpt-4o-mini",
   crypto: "openai/gpt-4o-mini",
   arbitrage: "openai/gpt-4o-mini",
+  support: "openai/gpt-4o-mini",
   general: "openai/gpt-4o-mini",
 };

--- a/src/context/ChatContext.tsx
+++ b/src/context/ChatContext.tsx
@@ -1,12 +1,12 @@
 
 import React, { createContext, useState, useContext, ReactNode } from 'react';
 
-export type AgentId = 'mt4mt5' | 'crypto' | 'arbitrage' | null;
+export type AgentId = 'mt4mt5' | 'crypto' | 'arbitrage' | 'support';
 
 interface ChatContextType {
   isChatOpen: boolean;
   selectedAgent: AgentId;
-  openChat: (agentId: AgentId) => void;
+  openChat: (agentId: AgentId | null) => void;
   closeChat: () => void;
 }
 
@@ -14,18 +14,16 @@ const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
 export const ChatProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [isChatOpen, setIsChatOpen] = useState(false);
-  const [selectedAgent, setSelectedAgent] = useState<AgentId>(null);
+  const [selectedAgent, setSelectedAgent] = useState<AgentId>('support');
 
-  const openChat = (agentId: AgentId) => {
-    setSelectedAgent(agentId);
+  const openChat = (agentId: AgentId | null) => {
+    setSelectedAgent(agentId ?? 'support');
     setIsChatOpen(true);
   };
 
   const closeChat = () => {
     setIsChatOpen(false);
-    // Keep selectedAgent in case we want to reopen, or set to null.
-    // Setting to null is cleaner to avoid stale state.
-    setSelectedAgent(null);
+    setSelectedAgent('support');
   };
 
   return (

--- a/src/hooks/chat/useChatInput.ts
+++ b/src/hooks/chat/useChatInput.ts
@@ -3,7 +3,11 @@ import { useState, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 
 export type SubmitFn = (content: string) => Promise<boolean>;
-export const useChatInput = (submitMessage: SubmitFn) => {
+export const useChatInput = (
+  submitMessage: SubmitFn,
+  userId?: string,
+  threadId?: string
+) => {
   const [input, setInput] = useState('');
   const [isRecording, setIsRecording] = useState(false);
   const [isUploading, setIsUploading] = useState(false);
@@ -45,6 +49,13 @@ export const useChatInput = (submitMessage: SubmitFn) => {
           const { data } = supabase.storage
             .from('chat-uploads')
             .getPublicUrl(filePath);
+          if (userId && threadId) {
+            await supabase.from('chat_recordings').insert({
+              user_id: userId,
+              thread_id: threadId,
+              file_url: data.publicUrl,
+            });
+          }
           await submitMessage(data.publicUrl);
         } else {
           console.error('Audio upload error', error);
@@ -72,6 +83,13 @@ export const useChatInput = (submitMessage: SubmitFn) => {
         const { data } = supabase.storage
           .from('chat-uploads')
           .getPublicUrl(filePath);
+        if (userId && threadId) {
+          await supabase.from('chat_recordings').insert({
+            user_id: userId,
+            thread_id: threadId,
+            file_url: data.publicUrl,
+          });
+        }
         await submitMessage(data.publicUrl);
       } else {
         console.error('File upload error', error);

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -8,7 +8,7 @@ import { useMessageSubmission } from './chat/useMessageSubmission';
 
 export const useChat = (agentIdOverride?: AgentId) => {
   const { selectedAgent: agentFromContext } = useChatContext();
-  const selectedAgent = agentIdOverride !== undefined ? agentIdOverride : agentFromContext;
+  const selectedAgent: AgentId = agentIdOverride !== undefined ? agentIdOverride : agentFromContext ?? 'support';
 
   // Use the smaller hooks
   const { session, userId, userProfile, authRequired, setAuthRequired, clearAuthRequired } = useAuthState();
@@ -34,7 +34,7 @@ export const useChat = (agentIdOverride?: AgentId) => {
     handleFileUpload,
     isRecording,
     isUploading,
-  } = useChatInput(submitMessage);
+  } = useChatInput(submitMessage, userId, threadId);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -98,6 +98,45 @@ export type Database = {
           },
         ]
       }
+      chat_recordings: {
+        Row: {
+          id: string
+          user_id: string | null
+          thread_id: string | null
+          file_url: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          thread_id?: string | null
+          file_url: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          thread_id?: string | null
+          file_url?: string
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "chat_recordings_thread_id_fkey",
+            columns: ["thread_id"],
+            isOneToOne: false,
+            referencedRelation: "chat_threads",
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "chat_recordings_user_id_fkey",
+            columns: ["user_id"],
+            isOneToOne: false,
+            referencedRelation: "users",
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       chat_threads: {
         Row: {
           agent: string
@@ -365,6 +404,56 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      },
+      broker_registrations: {
+        Row: {
+          id: string
+          user_id: string | null
+          full_name: string
+          email: string
+          phone: string | null
+          country: string | null
+          platform: string | null
+          account_type: string | null
+          deposit: number | null
+          kyc_url: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id?: string | null
+          full_name: string
+          email: string
+          phone?: string | null
+          country?: string | null
+          platform?: string | null
+          account_type?: string | null
+          deposit?: number | null
+          kyc_url?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string | null
+          full_name?: string
+          email?: string
+          phone?: string | null
+          country?: string | null
+          platform?: string | null
+          account_type?: string | null
+          deposit?: number | null
+          kyc_url?: string | null
+          created_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "broker_registrations_user_id_fkey",
+            columns: ["user_id"],
+            isOneToOne: false,
+            referencedRelation: "users",
+            referencedColumns: ["id"]
+          }
+        ]
       }
     }
     Views: {

--- a/src/pages/BrokerRegistrationPage.tsx
+++ b/src/pages/BrokerRegistrationPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Navbar from '@/components/Navbar';
+import ParticleBackground from '@/components/ParticleBackground';
+import BrokerRegistrationForm from '@/components/forms/BrokerRegistrationForm';
+
+const BrokerRegistrationPage: React.FC = () => {
+  return (
+    <div className="relative min-h-screen bg-[#0D0D0D] pb-20">
+      <ParticleBackground />
+      <Navbar />
+      <main className="pt-32 px-6">
+        <h1 className="text-3xl font-bold text-white mb-6 text-center">Open Trading Account</h1>
+        <BrokerRegistrationForm />
+      </main>
+    </div>
+  );
+};
+
+export default BrokerRegistrationPage;

--- a/src/pages/HowItWorksPage.tsx
+++ b/src/pages/HowItWorksPage.tsx
@@ -48,7 +48,10 @@ const HowItWorksPage: React.FC = () => {
             How Ruyaa AI Works
           </h1>
 
-          <div className="bg-gradient-to-r from-primary/10 to-secondary/10 border border-primary/20 rounded-2xl p-12 mb-8 backdrop-blur-sm">
+          <motion.div
+            whileHover={{ scale: 1.02 }}
+            className="bg-[#1A1A1A] border border-gray-600 rounded-2xl p-12 mb-8 backdrop-blur-sm shadow-future-card"
+          >
             <motion.div
               animate={{ scale: [1, 1.05, 1] }}
               transition={{ duration: 3, repeat: Infinity }}
@@ -83,7 +86,7 @@ const HowItWorksPage: React.FC = () => {
                 <span className="font-medium">Live Demonstrations</span>
               </div>
             </div>
-          </div>
+          </motion.div>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -209,7 +209,7 @@ const Index = () => {
               </motion.button>
 
               <motion.button
-                onClick={() => openChat(null)}
+                onClick={() => openChat('support')}
                 className="bg-gray-800 border border-gray-600 text-white px-8 py-4 rounded-xl font-bold hover:bg-gray-700 hover:border-gray-500 hover:scale-102 transition-all duration-300 inline-flex items-center gap-2 relative"
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}

--- a/src/utils/videoUtils.ts
+++ b/src/utils/videoUtils.ts
@@ -34,22 +34,22 @@ export const getModernLessonContent = (lessonIndex: number) => {
     // Lesson 1: AI-Powered Account Setup
     {
       type: 'interactive',
-      title: '🤖 AI-Powered MT4/MT5 Setup',
-      titleAr: '🤖 إعداد MT4/MT5 بالذكاء الاصطناعي',
+      title: ' AI-Powered MT4/MT5 Setup',
+      titleAr: ' إعا MT4/MT5 بالكا الاصطناع',
       description: 'Let Ruyaa AI guide you through setting up your first trading account',
-      descriptionAr: 'دع ذكاء رؤيا الاصطناعي يوجهك لإعداد حساب التداول الأول',
+      descriptionAr: 'ع كا ا الاصطناع جهك لإعا حساب التال الأل',
       content: {
         steps: [
-          '🔗 Download MT4/MT5 from your broker',
-          '🎯 AI analyzes your trading goals',
-          '⚙️ Smart account configuration',
-          '✅ Ruyaa AI validates your setup'
+          ' Download MT4/MT5 from your broker',
+          ' AI analyzes your trading goals',
+          '️ Smart account configuration',
+          ' Ruyaa AI validates your setup'
         ],
         stepsAr: [
-          '🔗 تحميل MT4/MT5 من الوسيط الخاص بك',
-          '🎯 الذكاء الاصطناعي يحلل أهداف التداول',
-          '⚙️ تكوين الحساب الذكي',
-          '✅ ذكاء رؤيا يتحقق من الإعداد'
+          ' تحل MT4/MT5 ن السط الخاص بك',
+          ' الكا الاصطناع حلل أهاف التال',
+          '️ تكن الحساب الك',
+          ' كا ا تحقق ن الإعا'
         ],
         aiTips: [
           'Ruyaa AI recommends starting with demo accounts',
@@ -57,31 +57,31 @@ export const getModernLessonContent = (lessonIndex: number) => {
           'Get personalized trading insights powered by AI'
         ],
         aiTipsAr: [
-          'ذكاء رؤيا ينصح بالبدء بالحسابات التجريبية',
-          'ذكاؤنا الاصطناعي يراقب تقدمك ويقترح التحسينات',
-          'احصل على رؤى تداول شخصية مدعومة بالذكاء الاصطناعي'
+          'كا ا نصح بالب بالحسابات التجبة',
+          'كانا الاصطناع اقب تقك قتح التحسنات',
+          'احصل على ى تال شخصة عة بالكا الاصطناع'
         ]
       }
     },
     // Lesson 2: Understanding Market Interface
     {
       type: 'interactive',
-      title: '📊 AI Market Analysis Dashboard',
-      titleAr: '📊 لوحة تحليل السوق بالذكاء الاصطناعي',
+      title: ' AI Market Analysis Dashboard',
+      titleAr: ' لحة تحلل السق بالكا الاصطناع',
       description: 'Master MT4/MT5 interface with AI-powered insights',
-      descriptionAr: 'إتقان واجهة MT4/MT5 مع رؤى الذكاء الاصطناعي',
+      descriptionAr: 'إتقان اجهة MT4/MT5 ع ى الكا الاصطناع',
       content: {
         concepts: [
-          '📈 Charts: Your window to market movements',
-          '🎯 Order Types: Market, Limit, Stop orders explained',
-          '💰 Account Info: Balance, Equity, Margin tracking',
-          '🤖 AI Signals: Real-time trading recommendations'
+          ' Charts: Your window to market movements',
+          ' Order Types: Market, Limit, Stop orders explained',
+          ' Account Info: Balance, Equity, Margin tracking',
+          ' AI Signals: Real-time trading recommendations'
         ],
         conceptsAr: [
-          '📈 الرسوم البيانية: نافذتك على حركات السوق',
-          '🎯 أنواع الأوامر: أوامر السوق والحد والإيقاف',
-          '💰 معلومات الحساب: تتبع الرصيد والحقوق والهامش',
-          '🤖 إشارات الذكاء الاصطناعي: توصيات التداول الفورية'
+          ' الس البانة: نافتك على حكات السق',
+          ' أناع الأا: أا السق الح الإقاف',
+          ' علات الحساب: تتبع الص الحقق الهاش',
+          ' إشاات الكا الاصطناع: تصات التال الفة'
         ],
         examples: [
           'Example: EUR/USD chart showing AI-detected support at 1.0500',
@@ -93,22 +93,22 @@ export const getModernLessonContent = (lessonIndex: number) => {
     // Lesson 3: First Trade with AI
     {
       type: 'interactive',
-      title: '🚀 Your First AI-Guided Trade',
-      titleAr: '🚀 صفقتك الأولى بإرشاد الذكاء الاصطناعي',
+      title: ' Your First AI-Guided Trade',
+      titleAr: ' صفقتك الألى بإشا الكا الاصطناع',
       description: 'Execute your first trade with Ruyaa AI assistance',
-      descriptionAr: 'نفذ صفقتك الأولى بمساعدة ذكاء رؤيا',
+      descriptionAr: 'نف صفقتك الألى بساعة كا ا',
       content: {
         steps: [
-          '🎯 AI identifies high-probability trade setup',
-          '📊 Smart position sizing based on your risk profile',
-          '⚡ Execute trade with AI-calculated stop loss',
-          '📱 Monitor with real-time AI updates'
+          ' AI identifies high-probability trade setup',
+          ' Smart position sizing based on your risk profile',
+          ' Execute trade with AI-calculated stop loss',
+          ' Monitor with real-time AI updates'
         ],
         stepsAr: [
-          '🎯 الذكاء الاصطناعي يحدد إعداد التداول عالي الاحتمال',
-          '📊 تحديد حجم المركز الذكي بناءً على ملف المخاطر',
-          '⚡ تنفيذ الصفقة مع وقف الخسارة المحسوب بالذكاء الاصطناعي',
-          '📱 المراقبة مع التحديثات الفورية للذكاء الاصطناعي'
+          ' الكا الاصطناع ح إعا التال عال الاحتال',
+          ' تح حج الكز الك بناً على لف الخاط',
+          ' تنف الصفقة ع قف الخساة الحسب بالكا الاصطناع',
+          ' الاقبة ع التحثات الفة للكا الاصطناع'
         ],
         realExample: {
           pair: 'EUR/USD',
@@ -123,49 +123,49 @@ export const getModernLessonContent = (lessonIndex: number) => {
     // Lesson 4: Risk Management with AI
     {
       type: 'interactive',
-      title: '🛡️ AI-Powered Risk Management',
-      titleAr: '🛡️ إدارة المخاطر بالذكاء الاصطناعي',
+      title: '️ AI-Powered Risk Management',
+      titleAr: '️ إاة الخاط بالكا الاصطناع',
       description: 'Protect your capital with intelligent risk management',
-      descriptionAr: 'احم رأس مالك بإدارة المخاطر الذكية',
+      descriptionAr: 'اح أس الك بإاة الخاط الكة',
       content: {
         concepts: [
-          '💡 2% Rule: Never risk more than 2% per trade',
-          '🎯 AI calculates optimal position sizes automatically',
-          '📊 Dynamic stop-loss adjustment based on volatility',
-          '🤖 Ruyaa AI monitors correlation risk across trades'
+          ' 2% Rule: Never risk more than 2% per trade',
+          ' AI calculates optimal position sizes automatically',
+          ' Dynamic stop-loss adjustment based on volatility',
+          ' Ruyaa AI monitors correlation risk across trades'
         ],
         conceptsAr: [
-          '💡 قاعدة 2%: لا تخاطر بأكثر من 2% لكل صفقة',
-          '🎯 الذكاء الاصطناعي يحسب أحجام المراكز المثلى تلقائياً',
-          '📊 تعديل وقف الخسارة الديناميكي بناءً على التقلبات',
-          '🤖 ذكاء رؤيا يراقب مخاطر الارتباط عبر الصفقات'
+          ' قاعة 2%: لا تخاط بأكث ن 2% لكل صفقة',
+          ' الكا الاصطناع حسب أحجا الاكز الثلى تلقائاً',
+          ' تعل قف الخساة الناك بناً على التقلبات',
+          ' كا ا اقب خاط الاتباط عب الصفقات'
         ],
         scenarios: [
-          'Scenario 1: $1000 account → Max risk $20 per trade',
-          'Scenario 2: AI detects high volatility → Reduces position size',
-          'Scenario 3: Multiple correlated trades → AI warning system'
+          'Scenario 1: $1000 account  Max risk $20 per trade',
+          'Scenario 2: AI detects high volatility  Reduces position size',
+          'Scenario 3: Multiple correlated trades  AI warning system'
         ]
       }
     },
     // Lesson 5: Advanced AI Strategies
     {
       type: 'interactive',
-      title: '🧠 Advanced AI Trading Strategies',
-      titleAr: '🧠 استراتيجيات التداول المتقدمة بالذكاء الاصطناعي',
+      title: ' Advanced AI Trading Strategies',
+      titleAr: ' استاتجات التال التقة بالكا الاصطناع',
       description: 'Unlock professional trading with Ruyaa AI algorithms',
-      descriptionAr: 'افتح التداول المحترف بخوارزميات ذكاء رؤيا',
+      descriptionAr: 'افتح التال الحتف بخازات كا ا',
       content: {
         strategies: [
-          '🔄 AI Scalping: 1-5 minute AI-detected opportunities',
-          '📈 Trend Following: AI identifies major trend shifts',
-          '💎 Swing Trading: AI spots 3-7 day profit opportunities',
-          '🌊 Mean Reversion: AI catches oversold/overbought levels'
+          ' AI Scalping: 1-5 minute AI-detected opportunities',
+          ' Trend Following: AI identifies major trend shifts',
+          ' Swing Trading: AI spots 3-7 day profit opportunities',
+          ' Mean Reversion: AI catches oversold/overbought levels'
         ],
         strategiesAr: [
-          '🔄 المضاربة بالذكاء الاصطناعي: فرص 1-5 دقائق',
-          '📈 متابعة الاتجاه: الذكاء الاصطناعي يحدد تحولات الاتجاه الرئيسية',
-          '💎 التداول المتأرجح: الذكاء الاصطناعي يرصد فرص الربح 3-7 أيام',
-          '🌊 العودة للمتوسط: الذكاء الاصطناعي يلتقط مستويات الإفراط'
+          ' الضابة بالكا الاصطناع: فص 1-5 قائق',
+          ' تابعة الاتجاه: الكا الاصطناع ح تحلات الاتجاه الئسة',
+          ' التال التأجح: الكا الاصطناع ص فص البح 3-7 أا',
+          ' العة للتسط: الكا الاصطناع لتقط ستات الإفاط'
         ],
         aiFeatures: [
           'Smart entry/exit signals with 85%+ accuracy',
@@ -184,28 +184,28 @@ export const getModernLessonContent = (lessonIndex: number) => {
 export const getQuizData = (quizNumber: number) => {
   const quizzes = [
     {
-      title: '🤖 AI Trading Mastery Quiz',
-      titleAr: '🤖 اختبار إتقان التداول بالذكاء الاصطناعي',
+      title: ' AI Trading Mastery Quiz',
+      titleAr: ' اختبا إتقان التال بالكا الاصطناع',
       questions: [
         {
           question: 'What is the main advantage of AI-powered trading with Ruyaa?',
-          questionAr: 'ما هي الميزة الرئيسية للتداول بالذكاء الاصطناعي مع رؤيا؟',
+          questionAr: 'ا ه الزة الئسة للتال بالكا الاصطناع ع ا',
           options: ['Faster execution', '85%+ signal accuracy', 'Lower fees', 'Bigger profits'],
-          optionsAr: ['تنفيذ أسرع', 'دقة الإشارات 85%+', 'رسوم أقل', 'أرباح أكبر'],
+          optionsAr: ['تنف أسع', 'قة الإشاات 85%+', 'س أقل', 'أباح أكب'],
           correct: 1
         },
         {
           question: 'How does Ruyaa AI help with risk management?',
-          questionAr: 'كيف يساعد ذكاء رؤيا في إدارة المخاطر؟',
+          questionAr: 'كف ساع كا ا ف إاة الخاط',
           options: ['Eliminates all risk', 'Calculates optimal position sizes', 'Guarantees profits', 'Predicts the future'],
-          optionsAr: ['يلغي جميع المخاطر', 'يحسب أحجام المراكز المثلى', 'يضمن الأرباح', 'يتنبأ بالمستقبل'],
+          optionsAr: ['لغ جع الخاط', 'حسب أحجا الاكز الثلى', 'ضن الأباح', 'تنبأ بالستقبل'],
           correct: 1
         },
         {
           question: 'What should you do after completing this AI academy?',
-          questionAr: 'ماذا يجب أن تفعل بعد إكمال أكاديمية الذكاء الاصطناعي؟',
+          questionAr: 'اا جب أن تفعل بع إكال أكاة الكا الاصطناع',
           options: ['Start live trading immediately', 'Practice with demo + AI signals', 'Invest all savings', 'Ignore AI recommendations'],
-          optionsAr: ['ابدأ التداول المباشر فوراً', 'تدرب مع التجريبي + إشارات الذكاء الاصطناعي', 'استثمر جميع المدخرات', 'تجاهل توصيات الذكاء الاصطناعي'],
+          optionsAr: ['ابأ التال الباش فاً', 'تب ع التجب + إشاات الكا الاصطناع', 'استث جع الخات', 'تجاهل تصات الكا الاصطناع'],
           correct: 1
         }
       ]

--- a/supabase/migrations/20250617000000-add-chat-recordings.sql
+++ b/supabase/migrations/20250617000000-add-chat-recordings.sql
@@ -1,0 +1,15 @@
+-- Add table for storing uploaded voice recordings
+CREATE TABLE public.chat_recordings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  thread_id uuid REFERENCES public.chat_threads(id) ON DELETE CASCADE,
+  file_url text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.chat_recordings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_recordings REPLICA IDENTITY FULL;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.chat_recordings;
+
+CREATE POLICY "Users manage own recordings" ON public.chat_recordings
+  FOR ALL USING (auth.uid() = user_id);

--- a/supabase/migrations/20250617001000-add-broker-registrations.sql
+++ b/supabase/migrations/20250617001000-add-broker-registrations.sql
@@ -1,0 +1,21 @@
+-- Create table for broker registration forms
+CREATE TABLE public.broker_registrations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  full_name text NOT NULL,
+  email text NOT NULL,
+  phone text,
+  country text,
+  platform text,
+  account_type text,
+  deposit numeric,
+  kyc_url text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.broker_registrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.broker_registrations REPLICA IDENTITY FULL;
+ALTER PUBLICATION supabase_realtime ADD TABLE public.broker_registrations;
+
+CREATE POLICY "Users manage own broker registrations" ON public.broker_registrations
+  FOR ALL USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add `BrokerRegistrationForm` component and page
- add `/register/broker` route
- allow MT4/MT5 agent to direct users to broker form
- darken modal buttons in dashboard
- tone down colors in How It Works page and clean emojis
- add Supabase table and types for broker registrations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548ab30318832ebe3af35f1280af61