### PR TITLE
Fix OpenRouter setup and refine dashboard styling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
+# Public API key for OpenRouter (required)
 VITE_OPENROUTER_API_KEY=
+# Optional fallback name without VITE_ prefix
+OPENROUTER_API_KEY=
 VITE_TWELVEDATA_API_KEY=demo
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ This project is ready for deployment on [Vercel](https://vercel.com/). Configure
 
 ## Environment Variables
 See `.env.example` for the full list:
-- `VITE_OPENROUTER_API_KEY` – OpenRouter API key
+- `VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side)
+- `OPENROUTER_API_KEY` – Optional fallback key name
 - `VITE_TWELVEDATA_API_KEY` – TwelveData API key
 - `VITE_SUPABASE_URL` – Supabase project URL
 - `VITE_SUPABASE_ANON_KEY` – Supabase anon key

--- a/src/components/chat/HumanHelpModal.tsx
+++ b/src/components/chat/HumanHelpModal.tsx
@@ -24,7 +24,8 @@ const HumanHelpModal: React.FC<HumanHelpModalProps> = ({ open, onOpenChange }) =
   const [message, setMessage] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const openrouterApiKey = import.meta.env.VITE_OPENROUTER_API_KEY;
+  const openrouterApiKey =
+    import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {

--- a/src/components/dashboard/SessionsCard.tsx
+++ b/src/components/dashboard/SessionsCard.tsx
@@ -17,7 +17,7 @@ const getStatusClass = (status: string | null) => {
     case "active":
       return "bg-green-500/15 text-green-300 border border-green-400";
     case "pending":
-      return "bg-yellow-400/10 text-yellow-200 border border-yellow-300";
+      return "bg-[#3d2b1f]/30 text-white border border-[#5a4533]";
     case "closed":
       return "bg-red-500/10 text-red-300 border border-red-400";
     default:
@@ -32,7 +32,7 @@ const SessionsCard: React.FC<SessionsCardProps> = ({ sessions, onStartNow }) => 
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -6, boxShadow: "0 0 20px rgba(255,255,255,0.15)" }}
       transition={{ type: "spring", stiffness: 50 }}
-      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none group"
+      className="relative bg-[#1A1A1A] backdrop-blur-sm rounded-xl p-6 overflow-hidden focus-within:ring-2 focus-within:ring-green-400 outline-none group before:absolute before:inset-0 before:rounded-xl before:pointer-events-none before:bg-[radial-gradient(ellipse_at_top_left,rgba(255,255,255,0.1),transparent)]"
       tabIndex={0}
       aria-label="Arbitrage sessions"
     >

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-gradient-to-r from-yellow-600 to-yellow-500 text-black hover:from-yellow-500 hover:to-yellow-400 shadow-lg font-semibold transition-all duration-300 hover:scale-102 hover:shadow-xl",
+          "bg-gradient-to-br from-[#6b4e2e] to-[#2f241b] text-white border border-[#876246] hover:from-[#7f5c3a] hover:to-[#3b2d22] shadow-lg font-semibold transition-all duration-300 hover:scale-102 hover:shadow-xl",
         destructive:
           "bg-gradient-to-r from-red-600 to-red-500 text-white hover:from-red-500 hover:to-red-400 shadow-lg transition-all duration-300 hover:scale-102",
         outline:
@@ -19,7 +19,7 @@ const buttonVariants = cva(
           "bg-gradient-to-r from-gray-800 to-gray-700 text-white hover:from-gray-700 hover:to-gray-600 shadow-lg font-semibold transition-all duration-300 hover:scale-102 border border-gray-600",
         ghost:
           "hover:bg-gray-800 hover:text-white transition-all duration-300 backdrop-blur-sm hover:scale-102",
-        link: "text-yellow-500 underline-offset-4 hover:underline hover:text-yellow-400 transition-colors duration-300",
+        link: "text-[#d6bfa3] underline-offset-4 hover:underline hover:text-[#e6d2bd] transition-colors duration-300",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/config/agentConfig.ts
+++ b/src/config/agentConfig.ts
@@ -145,9 +145,9 @@ export const systemPrompts: Record<string, string> = {
 };
 
 export const modelMap: Record<string, string> = {
-  mt4mt5: "openai/gpt-4o-mini",
-  crypto: "openai/gpt-4o-mini",
-  arbitrage: "openai/gpt-4o-mini",
-  support: "openai/gpt-4o-mini",
-  general: "openai/gpt-4o-mini",
+  mt4mt5: "openai/gpt-4o",
+  crypto: "openai/gpt-4o",
+  arbitrage: "openai/gpt-4o",
+  support: "openai/gpt-4o",
+  general: "openai/gpt-4o",
 };

--- a/src/hooks/chat/useAiResponse.ts
+++ b/src/hooks/chat/useAiResponse.ts
@@ -6,7 +6,8 @@ import { Message } from '@/types/chat';
 import { AgentId } from '@/context/ChatContext';
 import { fetchAiResponse, getFallbackResponse } from '@/services/aiService';
 
-const openRouterApiKey = import.meta.env.VITE_OPENROUTER_API_KEY;
+const openRouterApiKey =
+  import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
 
 export const useAiResponse = () => {
   const [isAiLoading, setIsAiLoading] = useState(false);


### PR DESCRIPTION
## Summary
- improve .env example with fallback key
- document new environment variable in README
- update SessionsCard style to use mocha colors and add subtle reflection
- fallback to `OPENROUTER_API_KEY` and initialize OpenRouter client lazily
- use `openai/gpt-4o` for all agents
- allow fallback key in `useAiResponse`
- adjust default button style to mocha gradient
- use fallback key in HumanHelpModal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854963a532c832ebe014f94d7af05b6