### PR TITLE
Add signup avatar and fields

### DIFF
--- a/src/components/AI3DBadge.tsx
+++ b/src/components/AI3DBadge.tsx
@@ -8,7 +8,7 @@ import * as THREE from 'three';
 // 3D Brain Icon Component
 const Brain3D: React.FC<{ isHovered: boolean }> = ({ isHovered }) => {
   const meshRef = useRef<THREE.Mesh>(null);
-  const materialRef = useRef<any>(null);
+  const materialRef = useRef<THREE.MeshStandardMaterial | null>(null);
   
   useFrame((state) => {
     if (meshRef.current) {
@@ -38,16 +38,19 @@ const Brain3D: React.FC<{ isHovered: boolean }> = ({ isHovered }) => {
       {/* Neural network connections */}
       <group>
         {Array.from({ length: 8 }, (_, i) => (
-          <mesh key={i} position={[
-            -1.2 + Math.sin(i * 0.785) * 0.4,
-            Math.cos(i * 0.785) * 0.4,
-            Math.sin(i * 0.392) * 0.2
-          ]}>
+          <mesh
+            key={i}
+            position={[
+              -1.2 + Math.sin(i * 0.785) * 0.4,
+              Math.cos(i * 0.785) * 0.4,
+              Math.sin(i * 0.392) * 0.2,
+            ]}
+          >
             <sphereGeometry args={[0.02, 8, 8]} />
             <meshBasicMaterial color="#ffffff" opacity={0.6} transparent />
           </mesh>
         ))}
-      </div>
+      </group>
     </Float>
   );
 };
@@ -80,7 +83,7 @@ const BackgroundSphere: React.FC = () => {
 
 // 3D Text Component
 const Text3D: React.FC<{ isHovered: boolean }> = ({ isHovered }) => {
-  const textRef = useRef<any>(null);
+  const textRef = useRef<THREE.Mesh | null>(null);
   
   useFrame((state) => {
     if (textRef.current) {

--- a/src/components/AuthCard.tsx
+++ b/src/components/AuthCard.tsx
@@ -22,6 +22,12 @@ const AuthCard: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen w-full bg-gray-950 font-spacegrotesk">
       <div className="w-full max-w-md mx-auto bg-gray-900/80 backdrop-blur-md rounded-2xl shadow-xl p-8 relative z-10 animate-fade-in">
+        <img
+          src="/Ruyaa-Agent.png"
+          alt="Ruyaa Agent"
+          className="w-24 h-24 mx-auto mb-4 rounded-full cursor-pointer"
+          onClick={() => setActiveTab('signUp')}
+        />
         {/* Tabs */}
         <div className="flex justify-center mb-8">
           <button

--- a/src/components/auth/EmailAuthForm.tsx
+++ b/src/components/auth/EmailAuthForm.tsx
@@ -29,6 +29,8 @@ const EmailAuthForm: React.FC<EmailAuthFormProps> = ({ activeTab, setActiveTab }
   const [err, setErr] = useState<string | null>(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [fullName, setFullName] = useState("");
+  const [info, setInfo] = useState("");
   const navigate = useNavigate();
 
   async function handleSubmit(e: React.FormEvent) {
@@ -49,7 +51,14 @@ const EmailAuthForm: React.FC<EmailAuthFormProps> = ({ activeTab, setActiveTab }
         const { error } = await supabase.auth.signUp({
           email,
           password,
-          options: { emailRedirectTo: redirectTo }
+          options: {
+            emailRedirectTo: redirectTo,
+            data: {
+              full_name: fullName,
+              info,
+              avatar_url: "/Ruyaa-Agent.png"
+            }
+          }
         });
         if (error) setErr(error.message);
       }
@@ -91,6 +100,17 @@ const EmailAuthForm: React.FC<EmailAuthFormProps> = ({ activeTab, setActiveTab }
         <span className="mx-2 text-xs text-neutral-500">or</span>
         <div className="flex-grow border-t border-neutral-700" />
       </div>
+      {activeTab === "signUp" && (
+        <Input
+          className="bg-[#111111] border border-neutral-700 rounded-lg px-4 py-3 text-white placeholder:text-neutral-500 text-base"
+          placeholder="Full Name"
+          type="text"
+          required
+          value={fullName}
+          onChange={e => setFullName(e.target.value)}
+          disabled={loading}
+        />
+      )}
       <Input
         className="bg-[#111111] border border-neutral-700 rounded-lg px-4 py-3 text-white placeholder:text-neutral-500 text-base"
         placeholder="Email"
@@ -101,6 +121,16 @@ const EmailAuthForm: React.FC<EmailAuthFormProps> = ({ activeTab, setActiveTab }
         onChange={e => setEmail(e.target.value)}
         disabled={loading}
       />
+      {activeTab === "signUp" && (
+        <Input
+          className="bg-[#111111] border border-neutral-700 rounded-lg px-4 py-3 text-white placeholder:text-neutral-500 text-base"
+          placeholder="Info"
+          type="text"
+          value={info}
+          onChange={e => setInfo(e.target.value)}
+          disabled={loading}
+        />
+      )}
       <Input
         className="bg-[#111111] border border-neutral-700 rounded-lg px-4 py-3 text-white placeholder:text-neutral-500 text-base"
         placeholder="Password"


### PR DESCRIPTION
## Summary
- add avatar image to signup/login card
- expand sign up form with name and info fields
- store new user data in Supabase sign up call
- fix lint issues in `AI3DBadge`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bcc4e6654832e90c4c7677a891990