### PR TITLE
Fix build errors and clarify API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,19 @@ Ruyaa-AI is an AI-powered trading and assistant engine built with Vite, React an
 This project is ready for deployment on [Vercel](https://vercel.com/). Configure the included `vercel.json` and set your environment variables in the Vercel dashboard. Point the domain **ruyaacapital.com** to your Vercel project for production.
 
 ## Environment Variables
--See `.env.example` for the full list:
-- `VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side, e.g. `sk-or-...`)
-- `OPENROUTER_API_KEY` – Optional fallback key name
-- The agents default to the free `google/gemini-pro` model via OpenRouter
-- `VITE_TWELVEDATA_API_KEY` – TwelveData API key
-- `VITE_SUPABASE_URL` – Supabase project URL
-- `VITE_SUPABASE_ANON_KEY` – Supabase anon key
+See `.env.example` for the full list of configuration options.
+
+**Important**: the chat UI runs entirely in the browser, so the OpenRouter key must
+be exposed via the `VITE_OPENROUTER_API_KEY` variable. The plain `OPENROUTER_API_KEY`
+name is only useful for server-side code. If the key is not provided under the `VITE_`
+prefix, the agents will respond with a maintenance message.
+
+`VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side, e.g. `sk-or-...`)
+`OPENROUTER_API_KEY` – Optional fallback key name
+The agents default to the free `google/gemini-pro` model via OpenRouter
+`VITE_TWELVEDATA_API_KEY` – TwelveData API key
+`VITE_SUPABASE_URL` – Supabase project URL
+`VITE_SUPABASE_ANON_KEY` – Supabase anon key
 
 ## Security
 See [SECURITY.md](SECURITY.md) for security policies.

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -114,7 +114,7 @@ const DashboardPage = () => {
         >
           <motion.div variants={{ animate: { opacity: 1, y: 0, transition: { delay: 0.05 } }, initial: { opacity: 0, y: 20 } }}>
             <CustomAICard
-              imageSrc="/uploads/1344e471-1643-4f75-ae5c-9b0e36b02a0d.png"
+              imageSrc="/Ruyaa-Agent.png"
               buttonText="Market Sniper Set"
             />
           </motion.div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -177,7 +177,7 @@ const Index = () => {
                   buttonText: "Signal Engine"
                 },
                 {
-                  imageSrc: "/uploads/1344e471-1643-4f75-ae5c-9b0e36b02a0d.png", // Greenish Arbitrage Engine (reference image)
+                  imageSrc: "/Ruyaa-Agent.png",
                   buttonText: "Market Sniper Set"
                 },
                 {


### PR DESCRIPTION
## Summary
- document that the OpenRouter API key must use the VITE_ prefix

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bf45c7f14832eb38026ef366d2fbe