### PR TITLE
Fix OpenRouter key usage and Vercel build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ This optimization is implemented using Vercel's `ignoreCommand` feature in `verc
 See `.env.example` for the full list of configuration options.
 
 **Important**: the chat UI runs entirely in the browser, so the OpenRouter key must
-be exposed via the `VITE_OPENROUTER_API_KEY` variable. The plain `OPENROUTER_API_KEY`
-name is only useful for server-side code. If the key is not provided under the `VITE_`
-prefix, the agents will respond with a maintenance message.
+be exposed via the `VITE_OPENROUTER_API_KEY` variable. Server code can access the
+same value through `process.env.OPENROUTER_API_KEY` at build time. If the key is
+not provided under the `VITE_` prefix, the agents will respond with a maintenance
+message.
 
 `VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side, e.g. `sk-or-...`)
-`OPENROUTER_API_KEY` – Optional fallback key name
+`OPENROUTER_API_KEY` – Same key used for server code via `process.env.OPENROUTER_API_KEY`
 The agents default to the free `google/gemini-pro` model via OpenRouter
 `VITE_TWELVEDATA_API_KEY` – TwelveData API key
 `VITE_SUPABASE_URL` – Supabase project URL

--- a/src/components/chat/HumanHelpModal.tsx
+++ b/src/components/chat/HumanHelpModal.tsx
@@ -25,7 +25,9 @@ const HumanHelpModal: React.FC<HumanHelpModalProps> = ({ open, onOpenChange }) =
   const [loading, setLoading] = useState(false);
 
   const openrouterApiKey =
-    import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY ||
+    import.meta.env.VITE_OPENROUTER_API_KEY ||
+    import.meta.env.OPENROUTER_API_KEY;
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {

--- a/src/hooks/chat/useAiResponse.ts
+++ b/src/hooks/chat/useAiResponse.ts
@@ -7,7 +7,9 @@ import { AgentId } from '@/context/ChatContext';
 import { fetchAiResponse, getFallbackResponse } from '@/services/aiService';
 
 const openRouterApiKey =
-  import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY ||
+  import.meta.env.VITE_OPENROUTER_API_KEY ||
+  import.meta.env.OPENROUTER_API_KEY;
 
 export const useAiResponse = () => {
   const [isAiLoading, setIsAiLoading] = useState(false);

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -5,7 +5,9 @@ import { systemPrompts, modelMap } from "@/config/agentConfig";
 
 const getOpenrouter = () => {
   const apiKey =
-    import.meta.env.VITE_OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY;
+    process.env.OPENROUTER_API_KEY ||
+    import.meta.env.VITE_OPENROUTER_API_KEY ||
+    import.meta.env.OPENROUTER_API_KEY;
   if (!apiKey) {
     console.error('OpenRouter API key missing! Check .env file and deployment settings');
     throw new Error('API_KEY_MISSING');
@@ -96,7 +98,7 @@ export const checkApiHealth = async (): Promise<{status: string, error?: string}
   try {
     const testResponse = await fetch('https://openrouter.ai/api/v1/auth/key', {
       headers: {
-        'Authorization': `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
+        'Authorization': `Bearer ${process.env.OPENROUTER_API_KEY}`,
         'Content-Type': 'application/json'
       }
     });

--- a/vercel.json
+++ b/vercel.json
@@ -2,9 +2,9 @@
   "build": {
     "env": {
       "ENVIRONMENT": "$VERCEL_ENV"
-    },
-    "ignoreCommand": "node ignore-build.js"
+    }
   },
+  "ignoreCommand": "node ignore-build.js",
   "routes": [
     {
       "src": "/api/.*",


### PR DESCRIPTION
## Summary
- use `process.env.OPENROUTER_API_KEY` as the primary env var
- clarify env-var instructions in README
- correct `vercel.json` `ignoreCommand` placement

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d6906e56c832e8ce3de5c3db0c430