### PR TITLE
Ensure OpenRouter setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # Public API key for OpenRouter (required)
 # Example: sk-or-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-VITE_OPENROUTER_API_KEY=
+VITE_OPENROUTER_API_KEY=sk-or-your-openrouter-key
 # Optional fallback name without VITE_ prefix
-OPENROUTER_API_KEY=
+OPENROUTER_API_KEY=sk-or-your-openrouter-key
 VITE_TWELVEDATA_API_KEY=demo
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=

--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ same value through `process.env.OPENROUTER_API_KEY` at build time. If the key is
 not provided under the `VITE_` prefix, the agents will respond with a maintenance
 message.
 
-`VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side, e.g. `sk-or-...`)
+`VITE_OPENROUTER_API_KEY` – OpenRouter API key (client side)
 `OPENROUTER_API_KEY` – Same key used for server code via `process.env.OPENROUTER_API_KEY`
-The agents default to the free `google/gemini-pro` model via OpenRouter
+The agents use free models on OpenRouter (currently `google/gemini-pro`).
+Make sure both variables are set in your `.env` file with your own key.
 `VITE_TWELVEDATA_API_KEY` – TwelveData API key
 `VITE_SUPABASE_URL` – Supabase project URL
 `VITE_SUPABASE_ANON_KEY` – Supabase anon key

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,24 +1,8 @@
 import OpenAI from "openai";
 import { Message } from "@/types/chat";
 import { AgentId } from "@/context/ChatContext";
+import { modelMap, systemPrompts } from "@/config/agentConfig";
 
-// 1. Set best free models for each agent
-export const modelMap = {
-  forex: "deepseek/deepseek-chat-v3-0324:free",
-  crypto: "deepseek/deepseek-chat-v3-0324:free",
-  arbitrage: "deepseek/deepseek-chat-v3-0324:free",
-  support: "deepseek/deepseek-chat-v3-0324:free",
-  general: "deepseek/deepseek-chat-v3-0324:free",
-};
-
-// 2. Define instructions (system prompts) for each agent
-export const agentInstructions = {
-  forex: "You are a financial trading expert focused on forex (foreign exchange) markets. Provide accurate, up-to-date, and clear forex trading advice, analysis, and explanations.",
-  crypto: "You are a crypto trading specialist. Offer concise, reliable insights, strategies, and safety tips for trading cryptocurrencies.",
-  arbitrage: "You are an advanced financial arbitrage advisor. Identify cross-market arbitrage opportunities and explain complex concepts simply.",
-  support: "You are a helpful customer support assistant for Ruyaa Capital. Answer questions and resolve issues politely, quickly, and thoroughly.",
-  general: "You are a helpful and knowledgeable AI assistant.",
-};
 
 const getOpenrouter = () => {
   const apiKey =
@@ -52,7 +36,7 @@ export const fetchAiResponse = async (
   try {
     // Get model and system prompt for this agent
     const model = modelMap[selectedAgent] || modelMap.general;
-    const instructions = agentInstructions[selectedAgent] || agentInstructions.general;
+    const instructions = systemPrompts[selectedAgent] || systemPrompts.general;
 
     // 3. Build message payload with system instructions
     const messages = [


### PR DESCRIPTION
## Summary
- document OpenRouter API key usage
- show example values in `.env.example`
- source models & prompts from `agentConfig` in `aiService`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867d64f4fe0832ea0d881363e7fa847