### PR TITLE
Add network access handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ trigger a redeploy so the key is embedded into the client bundle.
 
 ## Security
 See [SECURITY.md](SECURITY.md) for security policies.
+
+### Network Access
+
+Ruyaa-AI communicates with `openrouter.ai` to generate AI responses. If your
+environment restricts outbound network requests, the chat features will display a
+maintenance message. Ensure that connections to `https://openrouter.ai` are
+allowed or whitelist the domain in your firewall settings.

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -81,6 +81,12 @@ export const fetchAiResponse = async (
   } catch (error) {
     console.error("Error in fetchAiResponse:", error);
 
+    // Handle network errors explicitly so users know when access to
+    // openrouter.ai is blocked. `fetch` throws a TypeError in that case.
+    if (error instanceof TypeError) {
+      return "Network request to OpenRouter failed. Ensure access to openrouter.ai is allowed.";
+    }
+
     if (error instanceof OpenAI.APIError) {
       if (error.status === 401) {
         return "I'm having service maintenance - please wait while I prepare myself and come back soon. 🛠️";


### PR DESCRIPTION
## Summary
- detect blocked network requests to OpenRouter and surface an explicit error
- document network requirements for OpenRouter in the README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867d8fbafd0832e94119ffacb8c0a7a